### PR TITLE
Provide a session reset mechanism

### DIFF
--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -65,7 +65,9 @@ module.exports = {
 
                     req.user.accessToken = body["access_token"];
                     req.user.expires = (Date.now() + (30 * 60 * 1000));
-                    resolve();
+                    req.login(req.user, error => {
+                        resolve();
+                    });
                 });
             }
         });

--- a/server/main.js
+++ b/server/main.js
@@ -47,7 +47,14 @@ server.use(restify.queryParser());
 server.use(passport.initialize());
 server.use(passport.session());
 
-server.get('/auth/error', (req, res, next) => {
+server.get("/auth/reset", (req, res, next) => {
+    req.logout();
+    req.session.destroy();
+    res.send(200);
+    next();
+});
+
+server.get("/auth/error", (req, res, next) => {
     return next(new restify.UnauthorizedError(""));
 });
 


### PR DESCRIPTION
• Fixes a bug where refreshing the user's access token didn't persist that token back into their session.  That resulted in hitting Google's authentication servers for every single API call after the access token expired
• Provides a session reset endpoint at `/auth/reset` to hopefully fix things for Alan.  Hopefully.  Fingers crossed.  It needed to be here regardless, though.
