### PR TITLE
Fix some session issues

### DIFF
--- a/server/env.js
+++ b/server/env.js
@@ -9,8 +9,8 @@ const knownEnvs = [
   'TRELLO_API_TOK',
   'TRELLO_CLIENT_SECRET',
   'ATC_TRELLO_BOARD_ID',
-  'HOST',
-  'LOG_LEVEL'
+  'LOG_LEVEL',
+  'ATC_SESSION_SECRET'
 ];
 
 if (appEnv.getServices() && Object.keys(appEnv.getServices()).length) {


### PR DESCRIPTION
- Extend sessions to 14 days, so hopefully we don't have to log in so often
- Extract session setup to one place instead of two
- Rename session secret env var to `ATC_SESSION_SECRET` so any other apps using the same CUPS instance don't have to use the same session secret
